### PR TITLE
RequestHelper definition modifications

### DIFF
--- a/dist/tool-box.js
+++ b/dist/tool-box.js
@@ -490,8 +490,24 @@ angular.module('jdalt.toolBox')
         }
       }
 
+      function getDefinition(type, method, url /*, data */) {
+        if (!definitions[type][method][url]) { // TODO: serialize data when/if this is expanded to other methods
+          definitions[type][method][url] = $httpBackend[type](method, url /*, data */)
+        }
+        return definitions[type][method][url]
+      }
+
+      // TODO: expand this out into `expect` and other methods, when/if it's useful
+      var definitions = {
+        when: {
+          GET: {}
+        }
+      }
+
       return {
         flush: $httpBackend.flush,
+
+        definitions: definitions,
 
         expectMany: function(def, params, res, overwriteParams) {
           if(!isPath(def) && typeof res == 'undefined')  res = []
@@ -504,7 +520,7 @@ angular.module('jdalt.toolBox')
             angular.merge(resObjs, overwriteParams)
           }
 
-          $httpBackend.expectGET(url).respond(200, resObjs)
+          return $httpBackend.expectGET(url).respond(200, resObjs)
         },
 
         whenMany: function(def, params, res, overwriteParams) {
@@ -518,7 +534,7 @@ angular.module('jdalt.toolBox')
             angular.merge(resObjs, overwriteParams)
           }
 
-          $httpBackend.whenGET(url).respond(200, resObjs)
+          return getDefinition('when', 'GET', url).respond(200, resObjs)
         },
 
         expectOne: function(def, id, res) {
@@ -529,7 +545,7 @@ angular.module('jdalt.toolBox')
           if(!isPath(def)) resObj = responseTransformer(resObj)
 
           var url = getUrl('find', def, id)
-          $httpBackend.expectGET(url).respond(200, resObj)
+          return $httpBackend.expectGET(url).respond(200, resObj)
         },
 
         whenOne: function(def, id, res) {
@@ -540,7 +556,7 @@ angular.module('jdalt.toolBox')
           if(!isPath(def)) resObj = responseTransformer(resObj)
 
           var url = getUrl('find', def, id)
-          $httpBackend.whenGET(url).respond(200, resObj)
+          return getDefinition('when', 'GET', url).respond(200, resObj)
         },
 
         // raw: function(url, req, res)
@@ -556,7 +572,7 @@ angular.module('jdalt.toolBox')
             }
           }
           var url = getUrl('findAll', def)
-          $httpBackend.expectPOST(url, req).respond(200, res)
+          return $httpBackend.expectPOST(url, req).respond(200, res)
         },
 
         // raw: function(url, id, req, res)
@@ -564,7 +580,7 @@ angular.module('jdalt.toolBox')
         expectUpdate: function(def, id, req, res) {
           var desc = transformUpdateRequest(def, id, req, res)
           var url = getUrl('find', def, desc.id)
-          $httpBackend.expectPUT(url, desc.req).respond(200, desc.res)
+          return $httpBackend.expectPUT(url, desc.req).respond(200, desc.res)
         },
 
         // raw: function(url, id, req, res)
@@ -572,12 +588,12 @@ angular.module('jdalt.toolBox')
         expectUpsert: function(def, id, req, res) {
           var desc = transformUpdateRequest(def, id, req, res)
           var url = getUrl('find', def, desc.id)
-          $httpBackend.expectPATCH(url, desc.req).respond(200, desc.res)
+          return $httpBackend.expectPATCH(url, desc.req).respond(200, desc.res)
         },
 
         expectDestroy: function(def, id) {
           var url = getUrl('find', def, id)
-          $httpBackend.expectDELETE(url).respond(204, '')
+          return $httpBackend.expectDELETE(url).respond(204, '')
         },
       }
     }]

--- a/src/request-helper.js
+++ b/src/request-helper.js
@@ -124,8 +124,24 @@ angular.module('jdalt.toolBox')
         }
       }
 
+      function getDefinition(type, method, url /*, data */) {
+        if (!definitions[type][method][url]) { // TODO: serialize data when/if this is expanded to other methods
+          definitions[type][method][url] = $httpBackend[type](method, url /*, data */)
+        }
+        return definitions[type][method][url]
+      }
+
+      // TODO: expand this out into `expect` and other methods, when/if it's useful
+      var definitions = {
+        when: {
+          GET: {}
+        }
+      }
+
       return {
         flush: $httpBackend.flush,
+
+        definitions: definitions,
 
         expectMany: function(def, params, res, overwriteParams) {
           if(!isPath(def) && typeof res == 'undefined')  res = []
@@ -138,7 +154,7 @@ angular.module('jdalt.toolBox')
             angular.merge(resObjs, overwriteParams)
           }
 
-          $httpBackend.expectGET(url).respond(200, resObjs)
+          return $httpBackend.expectGET(url).respond(200, resObjs)
         },
 
         whenMany: function(def, params, res, overwriteParams) {
@@ -152,7 +168,7 @@ angular.module('jdalt.toolBox')
             angular.merge(resObjs, overwriteParams)
           }
 
-          $httpBackend.whenGET(url).respond(200, resObjs)
+          return getDefinition('when', 'GET', url).respond(200, resObjs)
         },
 
         expectOne: function(def, id, res) {
@@ -163,7 +179,7 @@ angular.module('jdalt.toolBox')
           if(!isPath(def)) resObj = responseTransformer(resObj)
 
           var url = getUrl('find', def, id)
-          $httpBackend.expectGET(url).respond(200, resObj)
+          return $httpBackend.expectGET(url).respond(200, resObj)
         },
 
         whenOne: function(def, id, res) {
@@ -174,7 +190,7 @@ angular.module('jdalt.toolBox')
           if(!isPath(def)) resObj = responseTransformer(resObj)
 
           var url = getUrl('find', def, id)
-          $httpBackend.whenGET(url).respond(200, resObj)
+          return getDefinition('when', 'GET', url).respond(200, resObj)
         },
 
         // raw: function(url, req, res)
@@ -190,7 +206,7 @@ angular.module('jdalt.toolBox')
             }
           }
           var url = getUrl('findAll', def)
-          $httpBackend.expectPOST(url, req).respond(200, res)
+          return $httpBackend.expectPOST(url, req).respond(200, res)
         },
 
         // raw: function(url, id, req, res)
@@ -198,7 +214,7 @@ angular.module('jdalt.toolBox')
         expectUpdate: function(def, id, req, res) {
           var desc = transformUpdateRequest(def, id, req, res)
           var url = getUrl('find', def, desc.id)
-          $httpBackend.expectPUT(url, desc.req).respond(200, desc.res)
+          return $httpBackend.expectPUT(url, desc.req).respond(200, desc.res)
         },
 
         // raw: function(url, id, req, res)
@@ -206,12 +222,12 @@ angular.module('jdalt.toolBox')
         expectUpsert: function(def, id, req, res) {
           var desc = transformUpdateRequest(def, id, req, res)
           var url = getUrl('find', def, desc.id)
-          $httpBackend.expectPATCH(url, desc.req).respond(200, desc.res)
+          return $httpBackend.expectPATCH(url, desc.req).respond(200, desc.res)
         },
 
         expectDestroy: function(def, id) {
           var url = getUrl('find', def, id)
-          $httpBackend.expectDELETE(url).respond(204, '')
+          return $httpBackend.expectDELETE(url).respond(204, '')
         },
       }
     }

--- a/test/dummy/http-request-directive.js
+++ b/test/dummy/http-request-directive.js
@@ -6,47 +6,54 @@ angular.module('dummy')
     restrict: 'A',
     scope: {},
     template: '<div>' +
-                '<button id="radio-one" ng-click="ctrl.getRocket()"><button>' +
-                '<button id="radio-many" ng-click="ctrl.getRockets()"><button>' +
-                '<button id="radio-usa" ng-click="ctrl.getUsRockets()"><button>' +
-                '<button id="launch-pad" ng-click="ctrl.postRocket()"><button>' +
-                '<button id="deep-orbit" ng-click="ctrl.updateRocket()"><button>' +
-                '<button id="low-orbit" ng-click="ctrl.upsertRocket()"><button>' +
-                '<button id="landing-zone" ng-click="ctrl.deleteRocket()"><button>' +
+                '<button id="radio-one" ng-click="ctrl.getRocket(\'#radio-one\')"><button>' +
+                '<button id="radio-many" ng-click="ctrl.getRockets(\'#radio-many\')"><button>' +
+                '<button id="radio-usa" ng-click="ctrl.getUsRockets(\'#radio-usa\')"><button>' +
+                '<button id="launch-pad" ng-click="ctrl.postRocket(\'#launch-pad\')"><button>' +
+                '<button id="deep-orbit" ng-click="ctrl.updateRocket(\'#deep-orbit\')"><button>' +
+                '<button id="low-orbit" ng-click="ctrl.upsertRocket(\'#low-orbit\')"><button>' +
+                '<button id="landing-zone" ng-click="ctrl.deleteRocket(\'#landing-zone\')"><button>' +
               '</div>',
     controllerAs: 'ctrl',
     controller: function(
+      $element,
       $http
     ) {
 
       var vm = this
 
-      vm.getRocket = function() {
-        $http.get('/api/rocket/1')
+      function setText(id) {
+        return function(resp) {
+          $element.find(id).text(resp.data)
+        }
       }
 
-      vm.getRockets = function() {
-        $http.get('/api/rocket')
+      vm.getRocket = function(id) {
+        $http.get('/api/rocket/1').then(setText(id))
       }
 
-      vm.getUsRockets = function() {
-        $http.get('/api/rocket?type=us')
+      vm.getRockets = function(id) {
+        $http.get('/api/rocket').then(setText(id))
       }
 
-      vm.postRocket = function() {
-        $http.post('/api/rocket', { action: 'Create' })
+      vm.getUsRockets = function(id) {
+        $http.get('/api/rocket?type=us').then(setText(id))
       }
 
-      vm.updateRocket = function() {
-        $http.put('/api/rocket/1', { action: 'Update' })
+      vm.postRocket = function(id) {
+        $http.post('/api/rocket', { action: 'Create' }).then(setText(id))
       }
 
-      vm.upsertRocket = function() {
-        $http.patch('/api/rocket/1', { action: 'Upsert' })
+      vm.updateRocket = function(id) {
+        $http.put('/api/rocket/1', { action: 'Update' }).then(setText(id))
       }
 
-      vm.deleteRocket = function() {
-        $http.delete('/api/rocket/1')
+      vm.upsertRocket = function(id) {
+        $http.patch('/api/rocket/1', { action: 'Upsert' }).then(setText(id))
+      }
+
+      vm.deleteRocket = function(id) {
+        $http.delete('/api/rocket/1').then(setText(id))
       }
 
     }

--- a/test/request-helper-test.js
+++ b/test/request-helper-test.js
@@ -13,62 +13,70 @@ describe('Fabricator', function() {
 
   it('should expectOne /api/rocket/1 when #radio-one clicked', function() {
     dom = compile()
-    Req.expectOne('/api/rocket', 1)
+    var req = Req.expectOne('/api/rocket', 1)
+    expect(req.respond).toEqual(jasmine.any(Function))
     dom.click('#radio-one')
     Req.flush()
   })
 
   it('expectOne should use of response when 2nd param is obj', function() {
     dom = compile()
-    Req.expectOne('/api/rocket', { id: 1 })
+    var req = Req.expectOne('/api/rocket', { id: 1 })
+    expect(req.respond).toEqual(jasmine.any(Function))
     dom.click('#radio-one')
     Req.flush()
   })
 
   it('should expectMany /api/rocket when #radio-many clicked', function() {
     dom = compile()
-    Req.expectMany('/api/rocket')
+    var req = Req.expectMany('/api/rocket')
+    expect(req.respond).toEqual(jasmine.any(Function))
     dom.click('#radio-many')
     Req.flush()
   })
 
   it('should expectMany /api/rocket with query params when #radio-usa clicked', function() {
     dom = compile()
-    Req.expectMany('/api/rocket', { type: 'us' })
+    var req = Req.expectMany('/api/rocket', { type: 'us' })
+    expect(req.respond).toEqual(jasmine.any(Function))
     dom.click('#radio-usa')
     Req.flush()
   })
 
   it('should expectCreate /api/rocket when #launch-pad clicked', function() {
     dom = compile()
-    Req.expectCreate('/api/rocket', { action: 'Create' })
+    var req = Req.expectCreate('/api/rocket', { action: 'Create' })
+    expect(req.respond).toEqual(jasmine.any(Function))
     dom.click('#launch-pad')
     Req.flush()
   })
 
   it('should expectUpdate /api/rocket/1 when #deep-orbit clicked', function() {
     dom = compile()
-    Req.expectUpdate('/api/rocket', 1, { action: 'Update' })
+    var req = Req.expectUpdate('/api/rocket', 1, { action: 'Update' })
+    expect(req.respond).toEqual(jasmine.any(Function))
     dom.click('#deep-orbit')
     Req.flush()
   })
 
   it('should expectUpsert /api/rocket/1 when #low-orbit clicked', function() {
     dom = compile()
-    Req.expectUpsert('/api/rocket', 1, { action: 'Upsert' })
+    var req = Req.expectUpsert('/api/rocket', 1, { action: 'Upsert' })
+    expect(req.respond).toEqual(jasmine.any(Function))
     dom.click('#low-orbit')
     Req.flush()
   })
 
   it('should expectDelete /api/rocket/1 when #landing-zone clicked', function() {
     dom = compile()
-    Req.expectDestroy('/api/rocket', 1)
+    var req = Req.expectDestroy('/api/rocket', 1)
+    expect(req.respond).toEqual(jasmine.any(Function))
     dom.click('#landing-zone')
     Req.flush()
   })
 
   describe('when', function() {
-    it('shoud respond with the same value for multiple requests', function() {
+    it('should respond with the same value for multiple requests', function() {
       dom = compile()
       Req.whenOne('/api/rocket', 1)
       dom.click('#radio-one')
@@ -77,13 +85,32 @@ describe('Fabricator', function() {
       Req.flush()
     })
 
-    it('shoud respond with the same value for multiple requests', function() {
+    it('should respond with the same value for multiple requests', function() {
       dom = compile()
       Req.whenMany('/api/rocket')
       dom.click('#radio-many')
       dom.click('#radio-many')
       dom.click('#radio-many')
       Req.flush()
+    })
+
+    it('should overwrite the previous value on multiple calls', function() {
+      dom = compile()
+      Req.whenOne('/api/rocket', 1, 'one first response')
+      Req.whenMany('/api/rocket', {}, ['many first response'])
+      dom.click('#radio-one')
+      dom.click('#radio-many')
+      Req.flush()
+      expect(dom.text('#radio-one')).toBe('one first response')
+      expect(dom.text('#radio-many')).toBe('many first response')
+
+      Req.whenOne('/api/rocket', 1, 'one second response')
+      Req.whenMany('/api/rocket', {}, ['many second response'])
+      dom.click('#radio-one')
+      dom.click('#radio-many')
+      Req.flush()
+      expect(dom.text('#radio-one')).toBe('one second response')
+      expect(dom.text('#radio-many')).toBe('many second response')
     })
   })
 


### PR DESCRIPTION
This makes subsequent calls to `whenOne` and `whenMany`, with the same parameters, overwrite the previous response definition.

It also returns the `$httpBackend.expect/when` objects, so that the calling code can call `.respond()` on it again in order to overwrite the response created in the RequestHelper call.